### PR TITLE
update dgun damage for mini bosses and raptor queen

### DIFF
--- a/lua/tweakunits3.lua
+++ b/lua/tweakunits3.lua
@@ -187,8 +187,10 @@ return {
 				weaponvelocity = 300,
 				damage = {
 					commanders = 0,
-					default = 20000,
-					raptors = 10000
+					default = 99999,
+					scavboss = 1000,
+					raptors = 10000,
+					raptorqueen = 20000
 				}
 			}
 		},
@@ -345,9 +347,10 @@ return {
 				weaponvelocity = 300,
 				damage = {
 					commanders = 0,
-					default = 20000,
+					default = 99999,
 					scavboss = 1000,
-					raptors = 10000
+					raptors = 10000,
+					raptorqueen = 20000
 				}
 			}
 		},
@@ -501,9 +504,10 @@ return {
 				weaponvelocity = 505,
 				damage = {
 					commanders = 0,
-					default = 20000,
+					default = 99999,
 					scavboss = 1000,
-					raptors = 10000
+					raptors = 10000,
+					raptorqueen = 20000
 				}
 			},
 			corcomeyelaser = {


### PR DESCRIPTION
default damage set to 99999 for mini bosses and other units. raptorqueen damage set to 20000 which was the previous default which would have applied to raptor queens.