### PR TITLE
remove redundant corcomlvl4 unit tweaks

### DIFF
--- a/lua/tweakdefs4.lua
+++ b/lua/tweakdefs4.lua
@@ -118,18 +118,6 @@ local miniQueenCommon = {
 }
 
 for f, u in pairs {
-	corcomlvl4 = {
-		weapondefs = {
-			disintegratorxl = {
-				damage = {
-					commanders = 0,
-					default = 99999,
-					scavboss = 1000,
-					raptorqueen = 20000
-				}
-			}
-		}
-	},
 	raptor_miniq_a = tableMerge(miniQueenCommon, {
 		customparams = raptorSquad(70, 80, 'berserk'),
 		weapondefs = {


### PR DESCRIPTION
remove redundant corcomlvl4 unit tweaks since they will be overwritten by tweakunits3. the balance looks good with the existing dgun damage.