### PR TITLE
add is_builder tag to t3 air aides

### DIFF
--- a/lua/tweakdefs8.lua
+++ b/lua/tweakdefs8.lua
@@ -219,6 +219,7 @@ for _, faction in pairs(factions) do
 			buildpic = 'ARMFIFY.DDS',
 			name = factionPrefix[faction] .. 'Epic Aide',
 			customparams = {
+				is_builder = true,
 				subfolder = 'ArmBots/T3',
 				techlevel = 3,
 				unitgroup = 'buildert3',


### PR DESCRIPTION
add is_builder to customparams for t3 air aides which was missing earlier. t3 ground aides already have this customparams which they inherit from the commander base units.