### PR TITLE
raptor hp tweak fixes: exclude queens, remove loop in unitdef_post

### DIFF
--- a/lua/tweakdefs/raptor hp 1.3X.lua
+++ b/lua/tweakdefs/raptor hp 1.3X.lua
@@ -1,4 +1,4 @@
--- NuttyB v1.52 1.3X HP
+--NuttyB v1.52 1.3X HP
 -- docs.google.com/spreadsheets/d/1QSVsuAAMhBrhiZdTihVfSCwPzbbZWDLCtXWP23CU0ko
 for unitName, unitDef in pairs(UnitDefs) do
     if string.sub(unitName, 1, 24) == "raptor_land_swarmer_heal" then
@@ -10,7 +10,7 @@ for unitName, unitDef in pairs(UnitDefs) do
         unitDef.maxthisunit = 0
     end
 
-    if unitDef.customparams and unitDef.customparams.subfolder == "other/raptors" and unitDef.health then
+    if unitDef.customparams and unitDef.customparams.subfolder == "other/raptors" and unitDef.health and not unitName:match('^raptor_queen_.*') then
         unitDef.health = unitDef.health * 1.3
         unitDef.sfxtypes = {}
         unitDef.explodas = unitDef.explodas
@@ -24,9 +24,7 @@ function UnitDef_Post(unitID, unitDef)
         oldUnitDef_Post(unitID, unitDef)
     end
 
-    for unitName, def in pairs(UnitDefs) do
-        if def.customparams and def.customparams.subfolder == "other/raptors" and def.health then
-            def.metalcost = math.floor(def.health * 0.576923077)
-        end
+    if unitDef.customparams and unitDef.customparams.subfolder == "other/raptors" and unitDef.health then
+        unitDef.metalcost = math.floor(unitDef.health * 0.576923077)
     end
 end

--- a/lua/tweakdefs/raptor hp 1.5X.lua
+++ b/lua/tweakdefs/raptor hp 1.5X.lua
@@ -1,4 +1,4 @@
--- NuttyB v1.52 1.5X HP
+--NuttyB v1.52 1.5X HP
 -- docs.google.com/spreadsheets/d/1QSVsuAAMhBrhiZdTihVfSCwPzbbZWDLCtXWP23CU0ko
 for unitName, unitDef in pairs(UnitDefs) do
     if string.sub(unitName, 1, 24) == "raptor_land_swarmer_heal" then
@@ -10,7 +10,7 @@ for unitName, unitDef in pairs(UnitDefs) do
         unitDef.maxthisunit = 0
     end
 
-    if unitDef.customparams and unitDef.customparams.subfolder == "other/raptors" and unitDef.health then
+    if unitDef.customparams and unitDef.customparams.subfolder == "other/raptors" and unitDef.health and not unitName:match('^raptor_queen_.*') then
         unitDef.health = unitDef.health * 1.5
         unitDef.sfxtypes = {}
         unitDef.explodas = unitDef.explodas
@@ -24,9 +24,7 @@ function UnitDef_Post(unitID, unitDef)
         oldUnitDef_Post(unitID, unitDef)
     end
 
-    for unitName, def in pairs(UnitDefs) do
-        if def.customparams and def.customparams.subfolder == "other/raptors" and def.health then
-            def.metalcost = math.floor(def.health * 0.466666667)
-        end
+    if unitDef.customparams and unitDef.customparams.subfolder == "other/raptors" and unitDef.health then
+        unitDef.metalcost = math.floor(unitDef.health * 0.466666667)
     end
 end

--- a/lua/tweakdefs/raptor hp 1.7X.lua
+++ b/lua/tweakdefs/raptor hp 1.7X.lua
@@ -1,4 +1,4 @@
--- NuttyB v1.52 1.7X HP
+--NuttyB v1.52 1.7X HP
 -- docs.google.com/spreadsheets/d/1QSVsuAAMhBrhiZdTihVfSCwPzbbZWDLCtXWP23CU0ko
 for unitName, unitDef in pairs(UnitDefs) do
     if string.sub(unitName, 1, 24) == "raptor_land_swarmer_heal" then
@@ -10,7 +10,7 @@ for unitName, unitDef in pairs(UnitDefs) do
         unitDef.maxthisunit = 0
     end
 
-    if unitDef.customparams and unitDef.customparams.subfolder == "other/raptors" and unitDef.health then
+    if unitDef.customparams and unitDef.customparams.subfolder == "other/raptors" and unitDef.health and not unitName:match('^raptor_queen_.*') then
         unitDef.health = unitDef.health * 1.7
         unitDef.sfxtypes = {}
         unitDef.explodas = unitDef.explodas
@@ -24,9 +24,7 @@ function UnitDef_Post(unitID, unitDef)
         oldUnitDef_Post(unitID, unitDef)
     end
 
-    for unitName, def in pairs(UnitDefs) do
-        if def.customparams and def.customparams.subfolder == "other/raptors" and def.health then
-            def.metalcost = math.floor(def.health * 0.411764706)
-        end
+    if unitDef.customparams and unitDef.customparams.subfolder == "other/raptors" and unitDef.health then
+        unitDef.metalcost = math.floor(unitDef.health * 0.411764706)
     end
 end

--- a/lua/tweakdefs/raptor hp 2.0X.lua
+++ b/lua/tweakdefs/raptor hp 2.0X.lua
@@ -1,4 +1,4 @@
--- NuttyB v1.52 2X HP
+--NuttyB v1.52 2X HP
 -- docs.google.com/spreadsheets/d/1QSVsuAAMhBrhiZdTihVfSCwPzbbZWDLCtXWP23CU0ko
 for unitName, unitDef in pairs(UnitDefs) do
     if string.sub(unitName, 1, 24) == "raptor_land_swarmer_heal" then
@@ -10,7 +10,7 @@ for unitName, unitDef in pairs(UnitDefs) do
         unitDef.maxthisunit = 0
     end
 
-    if unitDef.customparams and unitDef.customparams.subfolder == "other/raptors" and unitDef.health then
+    if unitDef.customparams and unitDef.customparams.subfolder == "other/raptors" and unitDef.health and not unitName:match('^raptor_queen_.*') then
         unitDef.health = unitDef.health * 2
         unitDef.sfxtypes = {}
         unitDef.explodas = unitDef.explodas
@@ -24,9 +24,7 @@ function UnitDef_Post(unitID, unitDef)
         oldUnitDef_Post(unitID, unitDef)
     end
 
-    for unitName, def in pairs(UnitDefs) do
-        if def.customparams and def.customparams.subfolder == "other/raptors" and def.health then
-            def.metalcost = math.floor(def.health * 0.35)
-        end
+    if unitDef.customparams and unitDef.customparams.subfolder == "other/raptors" and unitDef.health then
+        unitDef.metalcost = math.floor(unitDef.health * 0.35)
     end
 end

--- a/lua/tweakdefs/raptor hp 2.5X.lua
+++ b/lua/tweakdefs/raptor hp 2.5X.lua
@@ -1,4 +1,4 @@
--- NuttyB v1.52 2.5X HP
+--NuttyB v1.52 2.5X HP
 -- docs.google.com/spreadsheets/d/1QSVsuAAMhBrhiZdTihVfSCwPzbbZWDLCtXWP23CU0ko
 for unitName, unitDef in pairs(UnitDefs) do
     if string.sub(unitName, 1, 24) == "raptor_land_swarmer_heal" then
@@ -10,7 +10,7 @@ for unitName, unitDef in pairs(UnitDefs) do
         unitDef.maxthisunit = 0
     end
 
-    if unitDef.customparams and unitDef.customparams.subfolder == "other/raptors" and unitDef.health then
+    if unitDef.customparams and unitDef.customparams.subfolder == "other/raptors" and unitDef.health and not unitName:match('^raptor_queen_.*') then
         unitDef.health = unitDef.health * 2.5
         unitDef.sfxtypes = {}
         unitDef.explodas = unitDef.explodas
@@ -24,9 +24,7 @@ function UnitDef_Post(unitID, unitDef)
         oldUnitDef_Post(unitID, unitDef)
     end
 
-    for unitName, def in pairs(UnitDefs) do
-        if def.customparams and def.customparams.subfolder == "other/raptors" and def.health then
-            def.metalcost = math.floor(def.health * 0.3)
-        end
+    if unitDef.customparams and unitDef.customparams.subfolder == "other/raptors" and unitDef.health then
+        unitDef.metalcost = math.floor(unitDef.health * 0.3)
     end
 end

--- a/lua/tweakdefs/raptor hp 3.0X.lua
+++ b/lua/tweakdefs/raptor hp 3.0X.lua
@@ -1,4 +1,4 @@
--- NuttyB v1.52 3X HP
+--NuttyB v1.52 3X HP
 -- docs.google.com/spreadsheets/d/1QSVsuAAMhBrhiZdTihVfSCwPzbbZWDLCtXWP23CU0ko
 for unitName, unitDef in pairs(UnitDefs) do
     if string.sub(unitName, 1, 24) == "raptor_land_swarmer_heal" then
@@ -10,7 +10,7 @@ for unitName, unitDef in pairs(UnitDefs) do
         unitDef.maxthisunit = 0
     end
 
-    if unitDef.customparams and unitDef.customparams.subfolder == "other/raptors" and unitDef.health then
+    if unitDef.customparams and unitDef.customparams.subfolder == "other/raptors" and unitDef.health and not unitName:match('^raptor_queen_.*') then
         unitDef.health = unitDef.health * 3
         unitDef.sfxtypes = {}
         unitDef.explodas = unitDef.explodas
@@ -24,9 +24,7 @@ function UnitDef_Post(unitID, unitDef)
         oldUnitDef_Post(unitID, unitDef)
     end
 
-    for unitName, def in pairs(UnitDefs) do
-        if def.customparams and def.customparams.subfolder == "other/raptors" and def.health then
-            def.metalcost = math.floor(def.health * 0.25)
-        end
+    if unitDef.customparams and unitDef.customparams.subfolder == "other/raptors" and unitDef.health then
+        unitDef.metalcost = math.floor(unitDef.health * 0.25)
     end
 end

--- a/lua/tweakdefs/raptor hp 4.0X.lua
+++ b/lua/tweakdefs/raptor hp 4.0X.lua
@@ -1,4 +1,4 @@
--- NuttyB v1.52 4X HP
+--NuttyB v1.52 4X HP
 -- docs.google.com/spreadsheets/d/1QSVsuAAMhBrhiZdTihVfSCwPzbbZWDLCtXWP23CU0ko
 for unitName, unitDef in pairs(UnitDefs) do
     if string.sub(unitName, 1, 24) == "raptor_land_swarmer_heal" then
@@ -10,7 +10,7 @@ for unitName, unitDef in pairs(UnitDefs) do
         unitDef.maxthisunit = 0
     end
 
-    if unitDef.customparams and unitDef.customparams.subfolder == "other/raptors" and unitDef.health then
+    if unitDef.customparams and unitDef.customparams.subfolder == "other/raptors" and unitDef.health and not unitName:match('^raptor_queen_.*') then
         unitDef.health = unitDef.health * 4
         unitDef.sfxtypes = {}
         unitDef.explodas = unitDef.explodas
@@ -24,9 +24,7 @@ function UnitDef_Post(unitID, unitDef)
         oldUnitDef_Post(unitID, unitDef)
     end
 
-    for unitName, def in pairs(UnitDefs) do
-        if def.customparams and def.customparams.subfolder == "other/raptors" and def.health then
-            def.metalcost = math.floor(def.health * 0.1875)
-        end
+    if unitDef.customparams and unitDef.customparams.subfolder == "other/raptors" and unitDef.health then
+        unitDef.metalcost = math.floor(unitDef.health * 0.1875)
     end
 end

--- a/lua/tweakdefs/raptor hp 5.0X.lua
+++ b/lua/tweakdefs/raptor hp 5.0X.lua
@@ -1,4 +1,4 @@
--- NuttyB v1.52 5X HP
+--NuttyB v1.52 5X HP
 -- docs.google.com/spreadsheets/d/1QSVsuAAMhBrhiZdTihVfSCwPzbbZWDLCtXWP23CU0ko
 for unitName, unitDef in pairs(UnitDefs) do
     if string.sub(unitName, 1, 24) == "raptor_land_swarmer_heal" then
@@ -10,7 +10,7 @@ for unitName, unitDef in pairs(UnitDefs) do
         unitDef.maxthisunit = 0
     end
 
-    if unitDef.customparams and unitDef.customparams.subfolder == "other/raptors" and unitDef.health then
+    if unitDef.customparams and unitDef.customparams.subfolder == "other/raptors" and unitDef.health and not unitName:match('^raptor_queen_.*') then
         unitDef.health = unitDef.health * 5
         unitDef.sfxtypes = {}
         unitDef.explodas = unitDef.explodas
@@ -24,9 +24,7 @@ function UnitDef_Post(unitID, unitDef)
         oldUnitDef_Post(unitID, unitDef)
     end
 
-    for unitName, def in pairs(UnitDefs) do
-        if def.customparams and def.customparams.subfolder == "other/raptors" and def.health then
-            def.metalcost = math.floor(def.health * 0.15)
-        end
+    if unitDef.customparams and unitDef.customparams.subfolder == "other/raptors" and unitDef.health then
+        unitDef.metalcost = math.floor(unitDef.health * 0.15)
     end
 end


### PR DESCRIPTION
-fix: exclude raptor queen from hp multiplier, this was missed in the last update
-optimization: remove redundant loop in unitdef_post, because unitdef_post iterates through every unit already