### PR TITLE
T3 Air Aid compatability with Space mod

### DIFF
--- a/lua/tweakdefs8.lua
+++ b/lua/tweakdefs8.lua
@@ -199,7 +199,7 @@ for _, faction in pairs(factions) do
 		{
 			blocking = false,
 			canassist = true,
-			cruisealtitude = 3000,
+			cruisealtitude = 2000,
 			builddistance = 1750,
 			buildtime = 140000,
 			energycost = 200000,
@@ -211,7 +211,7 @@ for _, faction in pairs(factions) do
 			maxthisunit = 1,
 			metalcost = 13400,
 			speed = 25,
-			category = "OBJECT",
+			category = "SPACENOTOBJECT",
 			terraformspeed = 3000,
 			turninplaceanglelimit = 1.890,
 			turnrate = 1240,


### PR DESCRIPTION
This makes the Aid untargetable from Anti Air, and a spaceship if the space mod is installed.

Since this change only affects compatability and not nutty, I will explain what it does in the space mod.
- Orbital Raptors will attack it.
- Defence against orbital units (like raptor hives and turrets) attack it as well.
- No Anti Air targeting (like the old Object category)

To be fair, it does need more than 8k hp for it to be balanced in space, but I leave that decision to you if you want the T3 aid to have more health.

May I use this moment to ask why the cruise altitude is so high ?
I am not sure why, but this change will set the cruise altitude to 2k instead, or else its not selectable.