### PR TITLE
adjust doombringer spawn timing for > 20 queens

### DIFF
--- a/lua/tweakdefs4.lua
+++ b/lua/tweakdefs4.lua
@@ -1,4 +1,4 @@
---Mini Bosses v2e
+--Mini Bosses v2f
 -- Authors: RCore
 -- docs.google.com/spreadsheets/d/1QSVsuAAMhBrhiZdTihVfSCwPzbbZWDLCtXWP23CU0ko
 local unitDefs, tableMerge, tableCopy, raptor_matriarch_basic, customfusionexplo, spring = UnitDefs or {}, table.merge, table.copy, 'raptor_matriarch_basic', 'customfusionexplo', Spring

--- a/lua/tweakdefs4.lua
+++ b/lua/tweakdefs4.lua
@@ -32,8 +32,15 @@ end
 
 local mqNumQueens = spring.GetModOptions().raptor_queen_count or 1
 local mqDoomAngerScale = 1
-if nbQhpMult > 1.3 then mqDoomAngerScale = math.min(10, nbQhpMult / 1.3 * 0.9) end
-local mqDoomAnger = math.ceil(mqDoomAngerScale * (10 * (1.06 ^ math.max(0, mqNumQueens - 8))))
+mqDoomAngerScale = math.min(10, nbQhpMult / 1.3 * 0.9)
+
+-- Compact logic for hybrid exponential/linear growth
+local queenThreshold = 20
+local exponentialPart = 10 * (1.06 ^ math.max(0, math.min(mqNumQueens, queenThreshold) - 8))
+local linearPart = math.max(0, mqNumQueens - queenThreshold)
+local baseQueenAnger = exponentialPart + linearPart
+
+local mqDoomAnger = math.ceil(mqDoomAngerScale * baseQueenAnger)
 local mqAngerBoss = mqTimeMult * 100 + mqDoomAnger
 local maxDoombringers = math.max(3, scaledMax(math.floor((21 * mqNumQueens + 36) / 19)))
 

--- a/lua/tweakdefs4.lua
+++ b/lua/tweakdefs4.lua
@@ -1,4 +1,4 @@
---Mini Bosses v2f
+--Mini Bosses v2g
 -- Authors: RCore
 -- docs.google.com/spreadsheets/d/1QSVsuAAMhBrhiZdTihVfSCwPzbbZWDLCtXWP23CU0ko
 local unitDefs, tableMerge, tableCopy, raptor_matriarch_basic, customfusionexplo, spring = UnitDefs or {}, table.merge, table.copy, 'raptor_matriarch_basic', 'customfusionexplo', Spring
@@ -37,7 +37,8 @@ mqDoomAngerScale = math.min(10, nbQhpMult / 1.3 * 0.9)
 -- Compact logic for hybrid exponential/linear growth
 local queenThreshold = 20
 local exponentialPart = 10 * (1.06 ^ math.max(0, math.min(mqNumQueens, queenThreshold) - 8))
-local linearPart = math.max(0, mqNumQueens - queenThreshold)
+local x = math.max(0, mqNumQueens - queenThreshold)
+local linearPart = (x <= 80) and (0.6 * x - x*x/270) or (24.3 + (x - 80) * 0.15)
 local baseQueenAnger = exponentialPart + linearPart
 
 local mqDoomAnger = math.ceil(mqDoomAngerScale * baseQueenAnger)


### PR DESCRIPTION
adjust doombringer spawn timing for > 20 queens

doombringer spawn timing for > 20 queens was too long, so they would never spawn.
this reduces the doombringer spawn time for > 20 queens, but the spawn time is still too long.